### PR TITLE
add blank line after build constraint in unix implementation

### DIFF
--- a/shellcode_unix.go
+++ b/shellcode_unix.go
@@ -1,4 +1,5 @@
 // +build linux freebsd darwin
+
 package shellcode
 
 /*


### PR DESCRIPTION
by the go specification the blank line required bitwin build constraint and other data to build constraint be processed correctly. incorrect processing results in build errors in windows.